### PR TITLE
Prevent useless updates

### DIFF
--- a/internal/controller/budget.go
+++ b/internal/controller/budget.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"sort"
 
 	nodedisruptionv1alpha1 "github.com/criteo/node-disruption-controller/api/v1alpha1"
 	"github.com/golang-collections/collections/set"
@@ -21,6 +22,7 @@ func NodeSetToStringList(node_set *set.Set) []string {
 	node_set.Do(func(item interface{}) {
 		nodes = append(nodes, item.(string))
 	})
+	sort.Strings(nodes)
 	return nodes
 }
 

--- a/internal/controller/nodedisruption_controller.go
+++ b/internal/controller/nodedisruption_controller.go
@@ -72,7 +72,7 @@ func (r *NodeDisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// TODO: check to see if another one is marked in progress
 	if nd.Status.State == nodedisruptionv1alpha1.Pending || nd.Status.State == "" {
 		nd.Status.State = nodedisruptionv1alpha1.Processing
-		err = r.Update(ctx, nd.DeepCopy(), []client.UpdateOption{}...)
+		err = r.Status().Update(ctx, nd, []client.SubResourceUpdateOption{}...)
 		if err != nil {
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
The reconciler is reacting to every updates, even if they didn't change anything. The way to avoid infinite update loop is to not update k8s if we there was no modifications.
To do that we need the string lists to be stable (sorted).