### PR TITLE
Change how Status().Update() is made

### DIFF
--- a/internal/controller/nodedisruption_controller.go
+++ b/internal/controller/nodedisruption_controller.go
@@ -82,7 +82,7 @@ func (r *NodeDisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if nd.Status.State == "" {
 		nd.Status.State = nodedisruptionv1alpha1.Pending
-		err = r.Status().Update(ctx, nd, []client.SubResourceUpdateOption{}...)
+		err = r.Client.Status().Update(ctx, nd, []client.SubResourceUpdateOption{}...)
 
 		// Switch to pending and schedule another reconcile run
 		ctrl_result.Requeue = true
@@ -104,7 +104,7 @@ func (r *NodeDisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		nd.Status = status
 
-		err = r.Status().Update(ctx, nd, []client.SubResourceUpdateOption{}...)
+		err = r.Client.Status().Update(ctx, nd, []client.SubResourceUpdateOption{}...)
 		logger.Info("Updating Status, done with", "state", nd.Status.State)
 		if err != nil {
 			return ctrl_result, err


### PR DESCRIPTION
Before, this was possible:
```1. get (state is pending)
2. validate disruption -> granted
3. update() (status is accepted)
4. get (state is pending)
5. validate disruption -> failed because budget violation
6. update() (status is rejected)
7. update failed: "the object has been modified; please apply your changes to the latest version and try again"```

This is because `r.Client.Get` seems to fetch a stale ND in 4.

Changing `r.Status()` to `r.Client.Status()` seems to fix
the issue. It is weird as it should be equivalent