### PR TITLE
Batch of refactoring commits

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    - revive

--- a/internal/controller/budget.go
+++ b/internal/controller/budget.go
@@ -9,17 +9,17 @@ import (
 )
 
 func NewNodeSetFromStringList(nodes []string) *set.Set {
-	node_set := set.New()
+	nodeSet := set.New()
 	for _, node := range nodes {
-		node_set.Insert(node)
+		nodeSet.Insert(node)
 	}
-	return node_set
+	return nodeSet
 }
 
-func NodeSetToStringList(node_set *set.Set) []string {
+func NodeSetToStringList(nodeSet *set.Set) []string {
 	// Iterate over the set and append elements to the slice
-	nodes := make([]string, 0, node_set.Len())
-	node_set.Do(func(item interface{}) {
+	nodes := make([]string, 0, nodeSet.Len())
+	nodeSet.Do(func(item interface{}) {
 		nodes = append(nodes, item.(string))
 	})
 	sort.Strings(nodes)

--- a/internal/controller/budget.go
+++ b/internal/controller/budget.go
@@ -2,41 +2,19 @@ package controller
 
 import (
 	"context"
-	"sort"
 
 	nodedisruptionv1alpha1 "github.com/criteo/node-disruption-controller/api/v1alpha1"
-	"github.com/golang-collections/collections/set"
+	"github.com/criteo/node-disruption-controller/pkg/resolver"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func NewNodeSetFromStringList(nodes []string) *set.Set {
-	nodeSet := set.New()
-	for _, node := range nodes {
-		nodeSet.Insert(node)
-	}
-	return nodeSet
-}
-
-func NodeSetToStringList(nodeSet *set.Set) []string {
-	// Iterate over the set and append elements to the slice
-	nodes := make([]string, 0, nodeSet.Len())
-	nodeSet.Do(func(item interface{}) {
-		nodes = append(nodes, item.(string))
-	})
-	sort.Strings(nodes)
-	return nodes
-}
-
-type NodeDisruption struct {
-	ImpactedNodes *set.Set
-}
 
 type Budget interface {
 	// Sync ensure the budget's status is up to date
 	Sync(context.Context) error
 	// Check if the budget would be impacted by an operation on the provided set of nodes
-	IsImpacted(NodeDisruption) bool
+	IsImpacted(resolver.NodeSet) bool
 	// Return the number of disruption allowed considering a list of current node disruptions
-	TolerateDisruption(NodeDisruption) bool
+	TolerateDisruption(resolver.NodeSet) bool
 	// Check health make a synchronous health check on the underlying ressource of a budget
 	CheckHealth(context.Context) error
 	// Call a lifecycle hook in order to synchronously validate a Node Disruption

--- a/internal/controller/budget_test.go
+++ b/internal/controller/budget_test.go
@@ -7,6 +7,7 @@ import (
 
 	nodedisruptionv1alpha1 "github.com/criteo/node-disruption-controller/api/v1alpha1"
 	"github.com/criteo/node-disruption-controller/internal/controller"
+	"github.com/criteo/node-disruption-controller/pkg/resolver"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/internal/controller/budget_test.go
+++ b/internal/controller/budget_test.go
@@ -16,8 +16,8 @@ type MockBudget struct {
 	impacted bool
 	tolerate bool
 	// True if the budget was health checked
-	health_checked bool
-	health         error
+	healthChecked bool
+	health        error
 }
 
 func (m *MockBudget) Sync(context.Context) error {
@@ -36,13 +36,13 @@ func (m *MockBudget) TolerateDisruption(controller.NodeDisruption) bool {
 
 // Check health make a synchronous health check on the underlying ressource of a budget
 func (m *MockBudget) CheckHealth(context.Context) error {
-	m.health_checked = true
+	m.healthChecked = true
 	return m.health
 }
 
 // Check health make a synchronous health check on the underlying ressource of a budget
 func (m *MockBudget) CallHealthHook(context.Context, nodedisruptionv1alpha1.NodeDisruption) error {
-	m.health_checked = true
+	m.healthChecked = true
 	return m.health
 }
 
@@ -77,8 +77,8 @@ func TestValidationNoImpactedBudget(t *testing.T) {
 	budgets := []controller.Budget{&budget1, &budget2}
 
 	disruption := controller.NodeDisruption{controller.NewNodeSetFromStringList(nodes)}
-	any_failed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
-	assert.False(t, any_failed)
+	anyFailed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
+	assert.False(t, anyFailed)
 	assert.Equal(t, len(statuses), 0)
 }
 
@@ -106,8 +106,8 @@ func TestValidationImpactedAllOk(t *testing.T) {
 	budgets := []controller.Budget{&budget1, &budget2}
 
 	disruption := controller.NodeDisruption{controller.NewNodeSetFromStringList(nodes)}
-	any_failed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
-	assert.False(t, any_failed)
+	anyFailed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
+	assert.False(t, anyFailed)
 	assert.Equal(t, len(statuses), 2)
 }
 
@@ -132,14 +132,14 @@ func TestValidationFailAtDisruption(t *testing.T) {
 	budgets := []controller.Budget{&budget1, &budget2}
 
 	disruption := controller.NodeDisruption{controller.NewNodeSetFromStringList(nodes)}
-	any_failed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
-	assert.True(t, any_failed)
+	anyFailed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
+	assert.True(t, anyFailed)
 	assert.Equal(t, len(statuses), 1)
 	assert.False(t, statuses[0].Ok)
 	assert.NotEmpty(t, statuses[0].Reason, "Rejected budget should provide a reason")
 
-	assert.False(t, budget1.health_checked, "Health check should not be made if disruption check failed")
-	assert.False(t, budget2.health_checked, "Health check should not be made if disruption check failed")
+	assert.False(t, budget1.healthChecked, "Health check should not be made if disruption check failed")
+	assert.False(t, budget2.healthChecked, "Health check should not be made if disruption check failed")
 }
 
 func TestValidationFailAtHealth(t *testing.T) {
@@ -163,9 +163,9 @@ func TestValidationFailAtHealth(t *testing.T) {
 	budgets := []controller.Budget{&budget1, &budget2}
 
 	disruption := controller.NodeDisruption{controller.NewNodeSetFromStringList(nodes)}
-	any_failed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
-	assert.True(t, any_failed)
+	anyFailed, statuses := resolver.DoValidateDisruption(context.Background(), budgets, disruption)
+	assert.True(t, anyFailed)
 	assert.False(t, statuses[0].Ok)
 	assert.NotEmpty(t, statuses[0].Reason, "Rejected budget should provide a reason")
-	assert.True(t, budget1.health_checked)
+	assert.True(t, budget1.healthChecked)
 }


### PR DESCRIPTION
- Activate the revive linter to catch the case issues (snake vs camel)
- Move code around to improve readability of the reconciliation of Node Disruption

Note for the reviewer: focus on the readability and naming of the function chain in the NodeDisruption. 