### PR TITLE
Fix nil pointer dereference when trying to find the nodes of a PV that don't have affinity

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -53,6 +53,44 @@ func TestControllers(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
+func newPod(name, namespace, nodeName string, labels map[string]string) corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name:  "testcontainer",
+					Image: "ubuntu",
+				},
+			},
+		},
+		Status: corev1.PodStatus{}}
+}
+
+func newPVC(name, namespace, pvName string, labels map[string]string) corev1.PersistentVolumeClaim {
+	ressources := make(corev1.ResourceList, 1)
+	ressources[corev1.ResourceStorage] = *resource.NewQuantity(100, ressources.Storage().Format)
+	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName:  pvName,
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources:   corev1.ResourceRequirements{Requests: ressources},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{},
+	}
+}
+
 func newPVforNode(nodeName string) (pv corev1.PersistentVolume) {
 	ressources := make(corev1.ResourceList, 1)
 	ressources[corev1.ResourceStorage] = *resource.NewQuantity(100, ressources.Memory().Format)


### PR DESCRIPTION
Previously, we expected a PV with remote storage to have an empty set of selector but actually all the NodeAffinity section is missing. Now, we check if the pointer is nil.

Added 2 others commits:
- refactor of test in order to add the new tests for the fix
- fix flaky tests that could fail this PR
