### PR TITLE
Add a proper content type to Healthhook

### DIFF
--- a/internal/controller/applicationdisruptionbudget_controller.go
+++ b/internal/controller/applicationdisruptionbudget_controller.go
@@ -222,6 +222,7 @@ func (r *ApplicationDisruptionBudgetResolver) CallHealthHook(ctx context.Context
 	}
 
 	client := &http.Client{}
+	headers := make(map[string][]string, 1)
 
 	data, err := json.Marshal(nd)
 	if err != nil {
@@ -232,6 +233,10 @@ func (r *ApplicationDisruptionBudgetResolver) CallHealthHook(ctx context.Context
 	if err != nil {
 		return err
 	}
+
+	headers["Content-Type"] = []string{"application/json"}
+
+	req.Header = headers
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/controller/nodedisruption_controller_test.go
+++ b/internal/controller/nodedisruption_controller_test.go
@@ -248,6 +248,8 @@ var _ = Describe("NodeDisruption controller", func() {
 						Expect(err).Should(Succeed())
 						hookURL = req.URL.String()
 						hookCallCount++
+						// Validate that the hook is called with valid headers
+						Expect(req.Header["Content-Type"][0]).Should(Equal("application/json"))
 						w.WriteHeader(http.StatusOK)
 					}
 


### PR DESCRIPTION
Some application require the Content-Type be set to json to parse json. So now we provide it by default.


For another PR: all headers should be override-able in the health hook spec 