### PR TITLE
Add support for prometheus metrics in helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
         securityContext: {{- toYaml .Values.controllerManager.kubeRbacProxy.containerSecurityContext
           | nindent 10 }}
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
         command:
         - /manager
         env:

--- a/chart/templates/service-monitor.yaml
+++ b/chart/templates/service-monitor.yaml
@@ -1,0 +1,37 @@
+{{ if .Values.controllerManager.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}-prometheus-metrics
+  labels:
+    control-plane: controller-manager
+  {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: controller-manager
+  {{- include "chart.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: http
+    port: 8081
+    protocol: TCP
+    targetPort: http
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: node-disruption-controller
+  labels:
+    control-plane: controller-manager
+spec:
+  endpoints:
+  - port: http
+    interval: 60s
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,6 @@
 controllerManager:
+  serviceMonitor:
+    enabled: false
   kubeRbacProxy:
     args:
     - --secure-listen-address=0.0.0.0:8443
@@ -23,7 +25,7 @@ controllerManager:
   manager:
     args:
     - --health-probe-bind-address=:8081
-    - --metrics-bind-address=127.0.0.1:8080
+    - --metrics-bind-address=:8080
     - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
Prometheus metrics via prometheus operator can be enabled with `controllerManager.serviceMonitor.enabled: true`.