### PR TITLE
Remove healthURL to use healthHook only

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -98,14 +98,9 @@ ApplicationDisruptionBudgetSpec defines the desired state of ApplicationDisrupti
         <td><b><a href="#applicationdisruptionbudgetspechealthhook">healthHook</a></b></td>
         <td>object</td>
         <td>
-          Define a optional hook to call when validating a NodeDisruption. It perform a POST http request containing the NodeDisruption that is being validated. Maintenance will proceed only if the endpoint responds 2XX.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>healthURL</b></td>
-        <td>string</td>
-        <td>
-          Health URL is deprecated and will be removed in next version, please use healthHook instead. Health URL is an optional URL to call to validate the state of the application. Maintenance will proceed only if the endpoint responds 2XX.<br/>
+          Define a optional hook to call when validating a NodeDisruption.
+It perform a POST http request containing the NodeDisruption that is being validated.
+Maintenance will proceed only if the endpoint responds 2XX.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -131,7 +126,9 @@ ApplicationDisruptionBudgetSpec defines the desired state of ApplicationDisrupti
 
 
 
-Define a optional hook to call when validating a NodeDisruption. It perform a POST http request containing the NodeDisruption that is being validated. Maintenance will proceed only if the endpoint responds 2XX.
+Define a optional hook to call when validating a NodeDisruption.
+It perform a POST http request containing the NodeDisruption that is being validated.
+Maintenance will proceed only if the endpoint responds 2XX.
 
 <table>
     <thead>
@@ -187,7 +184,9 @@ PodSelector query over pods whose nodes are managed by the disruption budget.
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -199,7 +198,8 @@ PodSelector query over pods whose nodes are managed by the disruption budget.
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -221,14 +221,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -262,7 +266,9 @@ PVCSelector query over PVCs whose nodes are managed by the disruption budget.
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -274,7 +280,8 @@ PVCSelector query over PVCs whose nodes are managed by the disruption budget.
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -296,14 +303,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -355,7 +366,9 @@ DisruptionBudgetStatus defines the observed state of ApplicationDisruptionBudget
         <td><b>watchedNodes</b></td>
         <td>[]string</td>
         <td>
-          List of nodes that are being watched by the controller Disruption on this nodes will will be made according to the budget of this cluster.<br/>
+          List of nodes that are being watched by the controller
+Disruption on this nodes will will be made according to the budget
+of this cluster.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -517,7 +530,9 @@ NodeSelector query over pods whose nodes are managed by the disruption budget.
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -529,7 +544,8 @@ NodeSelector query over pods whose nodes are managed by the disruption budget.
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -551,14 +567,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -610,7 +630,9 @@ DisruptionBudgetStatus defines the observed state of ApplicationDisruptionBudget
         <td><b>watchedNodes</b></td>
         <td>[]string</td>
         <td>
-          List of nodes that are being watched by the controller Disruption on this nodes will will be made according to the budget of this cluster.<br/>
+          List of nodes that are being watched by the controller
+Disruption on this nodes will will be made according to the budget
+of this cluster.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -765,7 +787,9 @@ Label query over nodes that will be impacted by the disruption
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -777,7 +801,8 @@ Label query over nodes that will be impacted by the disruption
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -799,14 +824,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/api/v1alpha1/applicationdisruptionbudget_types.go
+++ b/api/v1alpha1/applicationdisruptionbudget_types.go
@@ -38,11 +38,6 @@ type ApplicationDisruptionBudgetSpec struct {
 	PodSelector metav1.LabelSelector `json:"podSelector,omitempty"`
 	// PVCSelector query over PVCs whose nodes are managed by the disruption budget.
 	PVCSelector metav1.LabelSelector `json:"pvcSelector,omitempty"`
-	// Health URL is deprecated and will be removed in next version, please use healthHook instead.
-	// Health URL is an optional URL to call to validate the state of the application.
-	// Maintenance will proceed only if the endpoint responds 2XX.
-	// +kubebuilder:validation:Optional
-	HealthURL *string `json:"healthURL,omitempty"`
 	// Define a optional hook to call when validating a NodeDisruption.
 	// It perform a POST http request containing the NodeDisruption that is being validated.
 	// Maintenance will proceed only if the endpoint responds 2XX.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -88,11 +88,6 @@ func (in *ApplicationDisruptionBudgetSpec) DeepCopyInto(out *ApplicationDisrupti
 	*out = *in
 	in.PodSelector.DeepCopyInto(&out.PodSelector)
 	in.PVCSelector.DeepCopyInto(&out.PVCSelector)
-	if in.HealthURL != nil {
-		in, out := &in.HealthURL, &out.HealthURL
-		*out = new(string)
-		**out = **in
-	}
 	out.HealthHook = in.HealthHook
 }
 

--- a/chart/templates/applicationdisruptionbudget-crd.yaml
+++ b/chart/templates/applicationdisruptionbudget-crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: applicationdisruptionbudgets.nodedisruption.criteo.com
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
   {{- include "chart.labels" . | nindent 4 }}
 spec:
@@ -34,14 +34,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -50,10 +55,10 @@ spec:
               ApplicationDisruptionBudget
             properties:
               healthHook:
-                description: Define a optional hook to call when validating a NodeDisruption.
-                  It perform a POST http request containing the NodeDisruption that
-                  is being validated. Maintenance will proceed only if the endpoint
-                  responds 2XX.
+                description: |-
+                  Define a optional hook to call when validating a NodeDisruption.
+                  It perform a POST http request containing the NodeDisruption that is being validated.
+                  Maintenance will proceed only if the endpoint responds 2XX.
                 properties:
                   caBundle:
                     description: a PEM encoded CA bundle which will be used to validate
@@ -65,12 +70,6 @@ spec:
                       form (`scheme://host:port/path`).
                     type: string
                 type: object
-              healthURL:
-                description: Health URL is deprecated and will be removed in next version,
-                  please use healthHook instead. Health URL is an optional URL to call
-                  to validate the state of the application. Maintenance will proceed
-                  only if the endpoint responds 2XX.
-                type: string
               maxDisruptions:
                 description: A NodeDisruption is allowed if at most "maxDisruptions"
                   nodes selected by selectors are unavailable after the disruption.
@@ -83,24 +82,25 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains
-                        values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a
-                            set of values. Valid operators are In, NotIn, Exists and
-                            DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator
-                            is In or NotIn, the values array must be non-empty. If the
-                            operator is Exists or DoesNotExist, the values array must
-                            be empty. This array is replaced during a strategic merge
-                            patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -112,11 +112,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator is
-                      "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -128,24 +127,25 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains
-                        values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a
-                            set of values. Valid operators are In, NotIn, Exists and
-                            DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator
-                            is In or NotIn, the values array must be non-empty. If the
-                            operator is Exists or DoesNotExist, the values array must
-                            be empty. This array is replaced during a strategic merge
-                            patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -157,11 +157,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator is
-                      "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -197,7 +196,8 @@ spec:
                 description: Number of disruption allowed on the nodes of this
                 type: integer
               watchedNodes:
-                description: List of nodes that are being watched by the controller
+                description: |-
+                  List of nodes that are being watched by the controller
                   Disruption on this nodes will will be made according to the budget
                   of this cluster.
                 items:

--- a/chart/templates/metrics-service.yaml
+++ b/chart/templates/metrics-service.yaml
@@ -14,4 +14,4 @@ spec:
     control-plane: controller-manager
   {{- include "chart.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.metricsService.ports | toYaml | nindent 2 -}}
+	{{- .Values.metricsService.ports | toYaml | nindent 2 }}

--- a/chart/templates/nodedisruption-crd.yaml
+++ b/chart/templates/nodedisruption-crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: nodedisruptions.nodedisruption.criteo.com
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
   {{- include "chart.labels" . | nindent 4 }}
 spec:
@@ -27,14 +27,19 @@ spec:
         description: NodeDisruption is the Schema for the nodedisruptions API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -48,24 +53,25 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains
-                        values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a
-                            set of values. Valid operators are In, NotIn, Exists and
-                            DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator
-                            is In or NotIn, the values array must be non-empty. If the
-                            operator is Exists or DoesNotExist, the values array must
-                            be empty. This array is replaced during a strategic merge
-                            patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -77,11 +83,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator is
-                      "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic

--- a/chart/templates/nodedisruptionbudget-crd.yaml
+++ b/chart/templates/nodedisruptionbudget-crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: nodedisruptionbudgets.nodedisruption.criteo.com
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
   {{- include "chart.labels" . | nindent 4 }}
 spec:
@@ -37,14 +37,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -67,24 +72,25 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains
-                        values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a
-                            set of values. Valid operators are In, NotIn, Exists and
-                            DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator
-                            is In or NotIn, the values array must be non-empty. If the
-                            operator is Exists or DoesNotExist, the values array must
-                            be empty. This array is replaced during a strategic merge
-                            patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -96,11 +102,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator is
-                      "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -137,7 +142,8 @@ spec:
                 description: Number of disruption allowed on the nodes of this
                 type: integer
               watchedNodes:
-                description: List of nodes that are being watched by the controller
+                description: |-
+                  List of nodes that are being watched by the controller
                   Disruption on this nodes will will be made according to the budget
                   of this cluster.
                 items:

--- a/config/crd/bases/nodedisruption.criteo.com_applicationdisruptionbudgets.yaml
+++ b/config/crd/bases/nodedisruption.criteo.com_applicationdisruptionbudgets.yaml
@@ -69,12 +69,6 @@ spec:
                       URL form (`scheme://host:port/path`).
                     type: string
                 type: object
-              healthURL:
-                description: |-
-                  Health URL is deprecated and will be removed in next version, please use healthHook instead.
-                  Health URL is an optional URL to call to validate the state of the application.
-                  Maintenance will proceed only if the endpoint responds 2XX.
-                type: string
               maxDisruptions:
                 description: A NodeDisruption is allowed if at most "maxDisruptions"
                   nodes selected by selectors are unavailable after the disruption.

--- a/internal/controller/applicationdisruptionbudget_controller.go
+++ b/internal/controller/applicationdisruptionbudget_controller.go
@@ -215,27 +215,6 @@ func (r *ApplicationDisruptionBudgetResolver) GetNamespacedName() nodedisruption
 	}
 }
 
-// Check health make a synchronous health check on the underlying resource of a budget
-func (r *ApplicationDisruptionBudgetResolver) CheckHealth(context.Context) error {
-	if r.ApplicationDisruptionBudget.Spec.HealthURL == nil {
-		return nil
-	}
-	resp, err := http.Get(*r.ApplicationDisruptionBudget.Spec.HealthURL)
-	if err != nil {
-		return err
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return nil
-	}
-	return fmt.Errorf("http server responded with non 2XX status code: %s", string(body))
-}
-
 // Call a lifecycle hook in order to synchronously validate a Node Disruption
 func (r *ApplicationDisruptionBudgetResolver) CallHealthHook(ctx context.Context, nd nodedisruptionv1alpha1.NodeDisruption) error {
 	if r.ApplicationDisruptionBudget.Spec.HealthHook.URL == "" {

--- a/internal/controller/budget.go
+++ b/internal/controller/budget.go
@@ -16,8 +16,6 @@ type Budget interface {
 	IsImpacted(resolver.NodeSet) bool
 	// Return the number of disruption allowed considering a list of current node disruptions
 	TolerateDisruption(resolver.NodeSet) bool
-	// Check health make a synchronous health check on the underlying resource of a budget
-	CheckHealth(context.Context) error
 	// Call a lifecycle hook in order to synchronously validate a Node Disruption
 	CallHealthHook(context.Context, nodedisruptionv1alpha1.NodeDisruption) error
 	// Apply the budget's status to Kubernetes

--- a/internal/controller/budget_test.go
+++ b/internal/controller/budget_test.go
@@ -36,12 +36,6 @@ func (m *MockBudget) TolerateDisruption(resolver.NodeSet) bool {
 }
 
 // Check health make a synchronous health check on the underlying resource of a budget
-func (m *MockBudget) CheckHealth(context.Context) error {
-	m.healthChecked = true
-	return m.health
-}
-
-// Check health make a synchronous health check on the underlying resource of a budget
 func (m *MockBudget) CallHealthHook(context.Context, nodedisruptionv1alpha1.NodeDisruption) error {
 	m.healthChecked = true
 	return m.health

--- a/internal/controller/nodedisruption_controller.go
+++ b/internal/controller/nodedisruption_controller.go
@@ -351,27 +351,6 @@ func (ndr *SingleNodeDisruptionReconciler) ValidateWithBudgetConstraints(ctx con
 	}
 
 	for _, budget := range impactedBudgets {
-		err := budget.CheckHealth(ctx)
-		ref := budget.GetNamespacedName()
-		if err != nil {
-			anyFailed = true
-			status := nodedisruptionv1alpha1.DisruptedBudgetStatus{
-				Reference: ref,
-				Reason:    fmt.Sprintf("Unhealthy: %s", err),
-				Ok:        false,
-			}
-			statuses = append(statuses, status)
-			logger.Info("Disruption rejected because: ", "status", status)
-			DisruptionBudgetRejectedTotal.WithLabelValues(ref.Namespace, ref.Name, ref.Kind).Inc()
-			break
-		}
-	}
-
-	if anyFailed {
-		return anyFailed, statuses
-	}
-
-	for _, budget := range impactedBudgets {
 		err := budget.CallHealthHook(ctx, ndr.NodeDisruption)
 		ref := budget.GetNamespacedName()
 		if err != nil {

--- a/internal/controller/nodedisruptionbudget_controller.go
+++ b/internal/controller/nodedisruptionbudget_controller.go
@@ -196,11 +196,6 @@ func (r *NodeDisruptionBudgetResolver) TolerateDisruption(disruptedNodes resolve
 	return r.NodeDisruptionBudget.Status.DisruptionsAllowed-disruptedNodesCount >= 0
 }
 
-// NodeDisruption CheckHealth is always true
-func (r *NodeDisruptionBudgetResolver) CheckHealth(context.Context) error {
-	return nil
-}
-
 // Call a lifecycle hook in order to synchronously validate a Node Disruption
 func (r *NodeDisruptionBudgetResolver) CallHealthHook(_ context.Context, _ nodedisruptionv1alpha1.NodeDisruption) error {
 	return nil


### PR DESCRIPTION
healthURL has been deprecated and replaced with healthHook.
healthHook is more powerful as it provides more configuration and it sends the nodeDisruption in the POST body.