### PR TITLE
Fix empty node name in watched nodes

### DIFF
--- a/internal/controller/applicationdisruptionbudget_controller_test.go
+++ b/internal/controller/applicationdisruptionbudget_controller_test.go
@@ -149,6 +149,9 @@ var _ = Describe("ApplicationDisruptionBudget controller", func() {
 				Expect(k8sClient.Create(ctx, &pod1)).Should(Succeed())
 				pod2 := newPod("podadb2", ADBNamespace, "node2", podLabels)
 				Expect(k8sClient.Create(ctx, &pod2)).Should(Succeed())
+				// Add a pod without node, i.e. pending
+				pod3 := newPod("podadb3", ADBNamespace, "", podLabels)
+				Expect(k8sClient.Create(ctx, &pod3)).Should(Succeed())
 				pvc3 := newPVC("pvc3", ADBNamespace, "node3-pv-local", podLabels)
 				Expect(k8sClient.Create(ctx, &pvc3)).Should(Succeed())
 

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -78,7 +78,9 @@ func (r *Resolver) GetNodesFromNamespacedPodSelector(ctx context.Context, podSel
 	}
 
 	for _, pod := range pods.Items {
-		nodeNames.Insert(pod.Spec.NodeName)
+		if pod.Spec.NodeName != "" {
+			nodeNames.Insert(pod.Spec.NodeName)
+		}
 	}
 	return nodeSet, nil
 }


### PR DESCRIPTION
Before, if we had a pod without a nodeName (which happens when a pod is pending), it was added to watchedNodes as empty string. It could also be
used in the intersection with disruption to calculate the budgets. Now, we ignore the pod if its node is missing.