### PR TITLE
Pin go correctly to 1.21

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20
+        go-version: '1.21'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20
+        go-version: '1.21'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1


### PR DESCRIPTION
If go-version is given as numerical it will resolve as 1.2 (instead of 1.20) So this commit use string instead and also upgrade setup-go.