### PR TITLE
Improve PVC phase handling

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -87,7 +87,9 @@ func newPVC(name, namespace, pvName string, labels map[string]string) corev1.Per
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources:   corev1.ResourceRequirements{Requests: resources},
 		},
-		Status: corev1.PersistentVolumeClaimStatus{},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
 	}
 }
 


### PR DESCRIPTION
Now:
- ignore PVC that are pending
- raise a specific error if the phase is not expected

Since Status is a subresource, it has to be updated directly in the tests