### PR TITLE
discard not yet reconciliated node disruption

### DIFF
--- a/api/v1alpha1/nodedisruption_types.go
+++ b/api/v1alpha1/nodedisruption_types.go
@@ -36,6 +36,7 @@ type NamespacedName struct {
 type NodeDisruptionState string
 
 const (
+	Unknown  NodeDisruptionState = ""
 	Pending  NodeDisruptionState = "pending"
 	Granted  NodeDisruptionState = "granted"
 	Rejected NodeDisruptionState = "rejected"

--- a/internal/controller/applicationdisruptionbudget_controller.go
+++ b/internal/controller/applicationdisruptionbudget_controller.go
@@ -294,6 +294,11 @@ func (r *ApplicationDisruptionBudgetResolver) ResolveDisruption(ctx context.Cont
 	}
 
 	for _, nd := range nodeDisruptions.Items {
+		if nd.Status.State == nodedisruptionv1alpha1.Unknown {
+			// node disruption has just been created and hasn't been reconciliated yet
+			continue
+		}
+
 		impactedNodes, err := r.Resolver.GetNodeFromNodeSelector(ctx, nd.Spec.NodeSelector)
 		if err != nil {
 			return 0, disruptions, err

--- a/internal/controller/nodedisruption_controller.go
+++ b/internal/controller/nodedisruption_controller.go
@@ -186,7 +186,7 @@ func (ndr *SingleNodeDisruptionReconciler) Reconcile(ctx context.Context) (err e
 func (ndr *SingleNodeDisruptionReconciler) TryTransitionState(ctx context.Context) (err error) {
 	logger := log.FromContext(ctx)
 	// If the state is unknown, switch it to Pending
-	if ndr.NodeDisruption.Status.State == "" {
+	if ndr.NodeDisruption.Status.State == nodedisruptionv1alpha1.Unknown {
 		ndr.NodeDisruption.Status.State = nodedisruptionv1alpha1.Pending
 
 		return err

--- a/internal/controller/nodedisruptionbudget_controller.go
+++ b/internal/controller/nodedisruptionbudget_controller.go
@@ -240,6 +240,11 @@ func (r *NodeDisruptionBudgetResolver) ResolveDisruption(ctx context.Context) (i
 	}
 
 	for _, nd := range nodeDisruptions.Items {
+		if nd.Status.State == nodedisruptionv1alpha1.Unknown {
+			// node disruption has just been created and hasn't been reconciliated yet
+			continue
+		}
+
 		impactedNodes, err := r.Resolver.GetNodeFromNodeSelector(ctx, nd.Spec.NodeSelector)
 		if err != nil {
 			return 0, disruptions, err


### PR DESCRIPTION
adb and ndb controllers are reporting information about node disruption not yet reconciliated, for which state is still unknown. It breaks contract of adb/ndb object status where reported nd should have a valid status.